### PR TITLE
セレクトスタンプの選択肢を動的に生成できるようにする

### DIFF
--- a/src/engine.ts
+++ b/src/engine.ts
@@ -216,15 +216,22 @@ export class WorkflowContext {
     return this.workflow.steps[++this.stepIndex];
   }
 
+  private evaluateActionWith(actionWith: unknown): DefaultActionWith {
+    if (typeof actionWith === 'string') {
+      actionWith = yaml.load(actionWith);
+    }
+    return actionWith as DefaultActionWith;
+  }
+
   private evaluateWorkflowStep(step: WorkflowStep, res: Response<any>): [WorkflowStep, Action] {
     const wstep = yaml.load(mustache.render(yaml.dump(step), this.data)) as WorkflowStep;
     const action = wstep.action;
+    const args = this.evaluateActionWith(wstep.with);
     if (isDefaultAction(action)) {
-      const args = wstep.with as DefaultActionWith;
       return [wstep, new MessageAction(action, args, args.to, res)];
     }
     if (isCustomAction(action)) {
-      return [wstep, new CustomAction(getCustomActionName(action), wstep.with)];
+      return [wstep, new CustomAction(getCustomActionName(action), args)];
     }
     throw new Error('Action is not implemented.');
   }


### PR DESCRIPTION
カスタムアクションとつなげることで、動的に選択肢を生成できるようにしています。

```
  - name: load data
    id: step0
    action: custom:actions/yml
    with:
      path: './data/options.yml'
    nowait: true

  - name: select
    action: daab:message:select
    with: |
      question: 選択してください。
      options:
        {{#step0.response}}
        - {{title}}
        {{/step0.response}}
```

with が文字列になっていて、テンプレート展開したあと、もう一度 yml で読み込み直します。