### PR TITLE
カスタムアクションで res を参照できるようにする

### DIFF
--- a/src/actions.ts
+++ b/src/actions.ts
@@ -97,16 +97,20 @@ export class MessageAction implements Action {
   }
 }
 
-type CustomActionFunction = (args: any) => Promise<ActionResponse | undefined>;
+type CustomActionFunction = (args: any, res?: Response<any>) => Promise<ActionResponse | undefined>;
 
 export class CustomAction implements Action {
   private readonly f: CustomActionFunction;
 
-  constructor(private readonly name: string, private readonly args: unknown) {
+  constructor(
+    private readonly name: string,
+    private readonly args: unknown,
+    readonly res: Response<any>
+  ) {
     this.f = require(name);
   }
 
   async execute(): Promise<ActionResponse | undefined> {
-    return this.f(this.args);
+    return this.f(this.args, this.res);
   }
 }

--- a/src/engine.ts
+++ b/src/engine.ts
@@ -224,7 +224,7 @@ export class WorkflowContext {
       return [wstep, new MessageAction(action, args, args.to, res)];
     }
     if (isCustomAction(action)) {
-      return [wstep, new CustomAction(getCustomActionName(action), wstep.with)];
+      return [wstep, new CustomAction(getCustomActionName(action), wstep.with, res)];
     }
     throw new Error('Action is not implemented.');
   }


### PR DESCRIPTION
カスタムアクションから res を参照したいことがありました。

* 複雑なメッセージの生成と送信をまとめてできる
* res.robot / res.robot.brain / res.robot.direct にアクセスできる
  * 過去のコードを再利用してカスタムアクションを作りやすい
